### PR TITLE
Refactored the ptype.definition utility in the ptypes library to allow for more control over constraints when being subclassed

### DIFF
--- a/lib/ptypes/ptype.py
+++ b/lib/ptypes/ptype.py
@@ -1815,6 +1815,32 @@ class definition(object):
         return cls.__set__(type, object)
 
     @classmethod
+    def define(cls, *args, **attributes):
+        """Add a definition to the cache keyed by the .type attribute of the definition. Return the original definition.
+
+        If any ``attributes`` are defined, the definition is duplicated with the specified attributes before being added to the cache.
+        """
+        def clone(definition, attributes=attributes):
+            res = {key : definition.__dict__[key] for key in definition.__dict__}
+            res.update(attributes)
+
+            name = res.pop('__name__', definition.__name__)
+            res = builtins.type(name, (definition,), res)
+            key = cls.__key__(res)
+            cls.__set__(key, res)
+            return definition
+
+        if attributes:
+            if len(definition):
+                raise error.AssertionError(cls, 'definition.define', message="Unexpected number of positional arguments. : {:d}".format(len(definition)))
+            return clone
+
+        definition, = args
+        key = cls.__key__(definition)
+        cls.__set__(key, definition)
+        return definition
+
+    @classmethod
     def lookup(cls, *args):
         """D.lookup(type[, default]) -> Lookup a ptype in the defintion D by ``type`` and return it.
 
@@ -1970,32 +1996,6 @@ class definition(object):
             other.cache = cls.cache
             return True
         return False
-
-    @classmethod
-    def define(cls, *args, **attributes):
-        """Add a definition to the cache keyed by the .type attribute of the definition. Return the original definition.
-
-        If any ``attributes`` are defined, the definition is duplicated with the specified attributes before being added to the cache.
-        """
-        def clone(definition, attributes=attributes):
-            res = {key : definition.__dict__[key] for key in definition.__dict__}
-            res.update(attributes)
-
-            name = res.pop('__name__', definition.__name__)
-            res = builtins.type(name, (definition,), res)
-            key = cls.__key__(res)
-            cls.__set__(key, res)
-            return definition
-
-        if attributes:
-            if len(definition):
-                raise error.AssertionError(cls, 'definition.define', message="Unexpected number of positional arguments. : {:d}".format(len(definition)))
-            return clone
-
-        definition, = args
-        key = cls.__key__(definition)
-        cls.__set__(key, definition)
-        return definition
 
 class wrapper_t(type):
     '''This type represents a type that is backed and sized by another ptype.

--- a/lib/ptypes/ptype.py
+++ b/lib/ptypes/ptype.py
@@ -1812,7 +1812,7 @@ class definition(object):
         DictType = types.DictType if sys.version_info.major < 3 else builtins.dict
         if not builtins.isinstance(cls.cache, DictType):
             raise error.TypeError(cls, 'definition.add', message="{:s} has an invalid type for the .cache attribute ({!r})".format(cls.__name__, cls.cache.__class__))
-        return cls.__set__(type, object, **kwargs)
+        return cls.__set__(type, object, **kwargs) or object
 
     @classmethod
     def define(cls, *args, **attributes):

--- a/lib/ptypes/ptype.py
+++ b/lib/ptypes/ptype.py
@@ -1766,10 +1766,18 @@ class definition(object):
             return '.'.join([__name__, 'unknown'])
 
     @classmethod
+    def __default__(cls):
+        """Overloadable: Return the default type to use when a matching instance could not be found.
+
+        By default, the implementation's `default` attribute is returned.
+        """
+        return cls.default
+
+    @classmethod
     def __key__(cls, type):
         """Overloadable: Return a unique key for the specified type.
 
-        By default, the attribute key in the implementation is used to fetch a unique attribute from the type.
+        By default, the `attribute` key of the implementation is used to fetch a unique attribute from the type.
         """
         return getattr(type, cls.attribute)
 
@@ -1837,7 +1845,7 @@ class definition(object):
             raise TypeError("get() takes 1 or 2 arguments ({:d} given)".format(len(type)))
 
         # extract the information from the arguments
-        type, default = (type) if len(type) > 1 else (type[0], cls.default)
+        type, default = (type) if len(type) > 1 else (type[0], cls.__default__())
 
         # search in the cache for the specified type
         try:
@@ -1862,7 +1870,7 @@ class definition(object):
             raise TypeError("withdefault() takes 1 or 2 arguments ({:d} given)".format(len(type)))
 
         # extract the information from the arguments
-        type, default = (type) if len(type) > 1 else (type[0], cls.default)
+        type, default = (type) if len(type) > 1 else (type[0], cls.__default__())
 
         # search in the cache for the specified type
         try:

--- a/lib/ptypes/ptype.py
+++ b/lib/ptypes/ptype.py
@@ -1808,7 +1808,8 @@ class definition(object):
     @classmethod
     def add(cls, type, object):
         """Add ``object`` to cache and key it by ``type``"""
-        if not builtins.isinstance(cls.cache, dict):
+        DictType = types.DictType if sys.version_info.major < 3 else builtins.dict
+        if not builtins.isinstance(cls.cache, DictType):
             raise error.AssertionError(cls, 'definition.add', message="{:s} has an invalid .cache attribute : {!r}".format(cls.__name__, cls.cache.__class__))
         return cls.__set__(type, object)
 
@@ -1956,9 +1957,8 @@ class definition(object):
         If any ``attributes`` are defined, the definition is duplicated with the specified attributes before being added to the cache.
         """
         def clone(definition):
-            res = dict(definition.__dict__)
+            res = {key : definition.__dict__[key] for key in definition.__dict__}
             res.update(attributes)
-            #res = builtins.type(res.pop('__name__', definition.__name__), definition.__bases__, res)
             res = builtins.type(res.pop('__name__', definition.__name__), (definition,), res)
             cls.add(cls.__key__(res), res)
             return definition
@@ -1967,6 +1967,7 @@ class definition(object):
             if len(definition):
                 raise error.AssertionError(cls, 'definition.define', message="Unexpected number of positional arguments. : {:d}".format(len(definition)))
             return clone
+
         res, = definition
         cls.add(cls.__key__(res), res)
         return res

--- a/lib/ptypes/ptype.py
+++ b/lib/ptypes/ptype.py
@@ -1766,6 +1766,14 @@ class definition(object):
             return '.'.join([__name__, 'unknown'])
 
     @classmethod
+    def __key__(cls, type):
+        """Overloadable: Return a unique key for the specified type.
+
+        By default, the attribute key in the implementation is used to fetch a unique attribute from the type.
+        """
+        return getattr(type, cls.attribute)
+
+    @classmethod
     def __set__(cls, type, object):
         '''Overloadable: Map the specified type to an object'''
         if cls.__has__(type):
@@ -1834,6 +1842,7 @@ class definition(object):
         # search in the cache for the specified type
         try:
             res = cls.__get__(type)
+
         except KeyError:
             res = default
 
@@ -1943,7 +1952,7 @@ class definition(object):
             res.update(attributes)
             #res = builtins.type(res.pop('__name__', definition.__name__), definition.__bases__, res)
             res = builtins.type(res.pop('__name__', definition.__name__), (definition,), res)
-            cls.add(getattr(res, cls.attribute), res)
+            cls.add(cls.__key__(res), res)
             return definition
 
         if attributes:
@@ -1951,7 +1960,7 @@ class definition(object):
                 raise error.AssertionError(cls, 'definition.define', message="Unexpected number of positional arguments. : {:d}".format(len(definition)))
             return clone
         res, = definition
-        cls.add(getattr(res, cls.attribute), res)
+        cls.add(cls.__key__(res), res)
         return res
 
 class wrapper_t(type):


### PR DESCRIPTION
This PR refactors the `ptype.definition` utility which is provided in the `ptypes.ptype` library module to enable an implementor to have more flexibility when creating their own type definition by subclassing it. Prior to this, the implementor only had a couple of hidden methods that were available to be overloaded within their subclass. The way these hidden methods were organized resulted in the methods having no context of any sort from their caller. This resulted in implementors having to incorporate a number of hacks (or to reimplement most of its functionality) when subclassing in order to apply arbitrary (or definition-specific) contraints to the record they're trying to work with.

This refactoring was done around the implementation of the `definition.__get__` classmethod so that it could be made responsible for returning a default value if the interface's request was unable to be satisfied. Each of the hidden methods now take variable keyword parameters which correspond to the parameters that were passed to said public interface. The implementation of the `definition.__has__` classmethod was also removed entirely as its original functionality could now be implemented using the new `definition.__get__` implementation. The rest of the `ptype.definition` utility was then also modified so that its interface could reuse more of the public interface to perform the majority of its logic. A variety of tests were also implemented for verifying the types and parameters of the different types of lookups that may be performed.

This closes issue #5.