### PR TITLE
Deprecate and remove the "parray.break_on_zero_sized_element" option from the ptypes configuration.

### DIFF
--- a/lib/ptypes/config.py
+++ b/lib/ptypes/config.py
@@ -266,7 +266,6 @@ class defaults:
         littleendian_name = field.type('littleendian_name', string_types, 'The formatspec to use when mangling the names for integers that are little-endian.')
 
     class parray:
-        break_on_zero_sized_element = field.bool('break_on_zero_sized_element', 'Terminate an array if an element size is invalid rather than looping indefinitely.')
         break_on_max_count = field.bool('break_on_max_count', 'If a dynamic array is larger than max_count, then raise an exception.')
         max_count = field.type('max_count', integer_types, 'Notify via a warning (exception if \'break_on_max_count\') when length is larger than max_count.')
 
@@ -341,7 +340,6 @@ defaults.display.threshold.details_message = ' ..skipped {leftover} rows, {skipp
 defaults.display.mangle_with_attributes = False
 
 # array types
-defaults.parray.break_on_zero_sized_element = False
 defaults.parray.break_on_max_count = False
 defaults.parray.max_count = sys.maxsize
 

--- a/lib/ptypes/dynamic.py
+++ b/lib/ptypes/dynamic.py
@@ -483,6 +483,10 @@ class union(__union_interface__):
             return '\n'.join(result)
         return "[{:x}] Empty []".format(self.getoffset())
 
+    def __blocksize_originalQ__(self):
+        '''Return whether the instance's blocksize has been rewritten by a definition.'''
+        cls = self.__class__
+        return utils.callable_eq(self.blocksize, cls.blocksize) and utils.callable_eq(cls.blocksize, union.blocksize)
     def blocksize(self):
         return self.object.blocksize()
     def size(self):

--- a/lib/ptypes/pbinary.py
+++ b/lib/ptypes/pbinary.py
@@ -419,6 +419,10 @@ class integer(type):
         res = self.__getvalue__()
         return bitmap.size(res)
 
+    def __blockbits_originalQ__(self):
+        '''Return whether the instance's blockbits have been rewritten by a definition.'''
+        cls = self.__class__
+        return utils.callable_eq(self.blockbits, cls.blockbits) and utils.callable_eq(cls.blockbits, integer.blockbits)
     def blockbits(self):
         if self.value is None:
             return 0
@@ -581,6 +585,10 @@ class enum(integer):
         #      they're within the boundaries of our type
         return
 
+    def __blockbits_originalQ__(self):
+        '''Return whether the instance's blockbits have been rewritten by a definition.'''
+        cls = self.__class__
+        return utils.callable_eq(self.blockbits, cls.blockbits) and utils.callable_eq(cls.blockbits, enum.blockbits)
     def blockbits(self):
         if self.value is None:
             return getattr(self, 'length', 0)
@@ -779,6 +787,10 @@ class container(type):
     def bits(self):
         return sum(item.bits() for item in self.value or [])
 
+    def __blockbits_originalQ__(self):
+        '''Return whether the instance's blockbits have been rewritten by a definition.'''
+        cls = self.__class__
+        return utils.callable_eq(self.blockbits, cls.blockbits) and utils.callable_eq(cls.blockbits, container.blockbits)
     def blockbits(self):
         if self.value is None:
             raise error.InitializationError(self, 'container.blockbits')
@@ -1419,6 +1431,10 @@ class array(__array_interface__):
         generator = (self.new(object, __name__=str(index), position=position) for index in range(self.length))
         return super(array, self).__deserialize_consumer__(consumer, generator)
 
+    def __blockbits_originalQ__(self):
+        '''Return whether the instance's blockbits have been rewritten by a definition.'''
+        cls = self.__class__
+        return utils.callable_eq(self.blockbits, cls.blockbits) and utils.callable_eq(cls.blockbits, array.blockbits)
     def blockbits(self):
         if self.initializedQ():
             return super(array, self).blockbits()
@@ -1455,6 +1471,10 @@ class struct(__structure_interface__):
         generator = (self.new(t, __name__=name, position=position) for t, name in self._fields_ or [])
         return super(struct, self).__deserialize_consumer__(consumer, generator)
 
+    def __blockbits_originalQ__(self):
+        '''Return whether the instance's blockbits have been rewritten by a definition.'''
+        cls = self.__class__
+        return utils.callable_eq(self.blockbits, cls.blockbits) and utils.callable_eq(cls.blockbits, struct.blockbits)
     def blockbits(self):
         if self.initializedQ():
             return super(struct, self).blockbits()
@@ -1512,6 +1532,10 @@ class terminatedarray(__array_interface__):
         '''Intended to be overloaded. Should return True if value ``item`` represents the end of the array.'''
         raise error.ImplementationError(self, 'terminatedarray.isTerminator')
 
+    def __blockbits_originalQ__(self):
+        '''Return whether the instance's blockbits have been rewritten by a definition.'''
+        cls = self.__class__
+        return utils.callable_eq(self.blockbits, cls.blockbits) and utils.callable_eq(cls.blockbits, terminatedarray.blockbits)
     def blockbits(self):
 
         # If the user implement a custom .blocksize() method, then use that to
@@ -1761,6 +1785,11 @@ class partial(ptype.container):
         size = value.bits()
         res = (size) if (size & 7) == 0x0 else ((size + 8) & ~7)
         return res // 8
+
+    def __blocksize_originalQ__(self):
+        '''Return whether the instance's blocksize has been rewritten by a definition.'''
+        cls = self.__class__
+        return utils.callable_eq(self.blocksize, cls.blocksize) and utils.callable_eq(cls.blocksize, partial.blocksize)
     def blocksize(self):
         value = self.value[0] if self.initializedQ() else self.__pb_object()
         size = value.blockbits()

--- a/lib/ptypes/pstr.py
+++ b/lib/ptypes/pstr.py
@@ -195,6 +195,10 @@ class string(ptype.type):
         ofs = offset - self.getoffset()
         return self[ ofs // self._object_().blocksize() ]
 
+    def __blocksize_originalQ__(self):
+        '''Return whether the instance's blocksize has been rewritten by a definition.'''
+        cls = self.__class__
+        return utils.callable_eq(self.blocksize, cls.blocksize) and utils.callable_eq(cls.blocksize, string.blocksize)
     def blocksize(self):
         return self._object_().blocksize() * self.length
 
@@ -456,6 +460,10 @@ class szstring(string):
             continue
         return self
 
+    def __blocksize_originalQ__(self):
+        '''Return whether the instance's blocksize has been rewritten by a definition.'''
+        cls = self.__class__
+        return utils.callable_eq(self.blocksize, cls.blocksize) and utils.callable_eq(cls.blocksize, szstring.blocksize)
     def blocksize(self):
         return self.size() if self.initializedQ() else self.load().size()
 

--- a/lib/ptypes/ptype.py
+++ b/lib/ptypes/ptype.py
@@ -1153,6 +1153,10 @@ class type(base):
         Log.info("type.size : {:s} : Unable to determine size of ptype.type, as object is still uninitialized.".format(self.instance()))
         return 0
 
+    def __blocksize_originalQ__(self):
+        '''Return whether the instance's blocksize has been rewritten by a definition.'''
+        cls = self.__class__
+        return utils.callable_eq(self.blocksize, cls.blocksize) and utils.callable_eq(cls.blocksize, type.blocksize)
     def blocksize(self):
         """Returns the expected size of the type
 
@@ -1197,6 +1201,10 @@ class container(base):
         """Returns a sum of the number of bytes that are currently in use by all sub-elements"""
         return sum(item.size() for item in self.value or [])
 
+    def __blocksize_originalQ__(self):
+        '''Return whether the instance's blocksize has been rewritten by a definition.'''
+        cls = self.__class__
+        return utils.callable_eq(self.blocksize, cls.blocksize) and utils.callable_eq(cls.blocksize, container.blocksize)
     def blocksize(self):
         """Returns a sum of the bytes that are expected to be read"""
         if self.value is None:
@@ -2087,6 +2095,10 @@ class wrapper_t(type):
     def initializedQ(self):
         return self.__object__ is not None and self.__object__.initializedQ()
 
+    def __blocksize_originalQ__(self):
+        '''Return whether the instance's blocksize has been rewritten by a definition.'''
+        cls = self.__class__
+        return utils.callable_eq(self.blocksize, cls.blocksize) and utils.callable_eq(cls.blocksize, wrapper_t.blocksize)
     def blocksize(self):
         if self.__object__ is not None:
             try:


### PR DESCRIPTION
This PR removes the "parray.break_on_zero_sized_element" configuration option from ptypes. Rather than letting the user choose whether they should avoid a potential infinite recursion issue, we check attributes from the array definition and its element type in order to determine whether we should interrupt loading the array.

If the currently loaded array element is zero-sized, the element is not being dynamically generated, and the blocksize has not been customized in any way, then we interrupt the load. This implies that we can predict that the array will \_always\_ infinitely recurse because the next element that's loaded for the array will have the exact same size (and thus the same issue) due to the user mistakenly specifying a constant zero-sized element. This way we allow the user to shoot themselves in the foot if they want to. We also log a warning telling the user that they're shooting themselves in the foot.

This adds a hidden public method to all of our base classes with the name "__blocksize_originalQ__" which is called by the internals to determine whether the implementor has defined a custom blocksize. For consistency, we also include a "__blockbits_originalQ__" method which does the same, but for binary types. This method isn't actually used at the moment, however.

This fixes issue #7.